### PR TITLE
Build conda package; test local, global, and conda installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,49 @@
 language: node_js
+
 os:
   - linux
   - osx
+
 node_js:
   - "node"
+
 env:
-  - GLOBAL_INSTALL_FLAG=--global
-  - GLOBAL_INSTALL_FLAG=
+  - INSTALL_TYPE=npm_local  GLOBAL_INSTALL=false
+  - INSTALL_TYPE=npm_global GLOBAL_INSTALL=true
+  - INSTALL_TYPE=conda      GLOBAL_INSTALL=true
+
 install:
-  - npm install $GLOBAL_INSTALL_FLAG
-services:
-  - mongodb
+  - case "$INSTALL_TYPE" in
+      "npm_local" )
+        npm install . ;;
+      "npm_global" )
+        npm install --global . ;;
+      "conda" )
+        if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        else
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        fi;
+        bash miniconda.sh -b -p $HOME/miniconda;
+        source $HOME/miniconda/etc/profile.d/conda.sh;
+        hash -r;
+        conda config --set always_yes yes --set changeps1 no --set auto_update_conda no;
+        conda create -n mljs-env conda-build;
+        conda info -a;
+        conda activate mljs-env;
+        conda build conda-recipe;
+        conda_pkg=$(conda build conda-recipe --output);
+        conda install --use-local $conda_pkg ;;
+    esac
+
+script:
+  - if [ "$GLOBAL_INSTALL" = "true" ]; then
+      npm list -g mountainlab-js;
+      echo npm prefix = `npm prefix`;
+    else
+      PATH="$PWD"/bin:"$PATH";
+      echo npm prefix --global npm prefix --global;
+    fi;
+  - which ml-config;
+  - ml-config;
+  - ml-list-processors;

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   git_rev: HEAD
 
 build:
-  number: 4
+  number: 5
   script:
     - tgzfile=$(npm pack)
     - npm install -g $tgzfile
@@ -16,11 +16,12 @@ build:
     - cp conda-recipe/mountainlab_activate.sh "$PREFIX"/etc/conda/activate.d/
     - cp conda-recipe/mountainlab_deactivate.sh "$PREFIX"/etc/conda/deactivate.d/
     - mkdir -p "$PREFIX"/etc/mountainlab/{packages,database}
+    # conda-build doesn't keep empty directories
+    - touch "$PREFIX"/etc/mountainlab/{packages,database}/.conda_keep
 
 requirements:
   build:
     - nodejs
-
   run:
     - nodejs
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,13 +8,14 @@ source:
   git_rev: HEAD
 
 build:
-  number: 2
+  number: 4
   script:
     - tgzfile=$(npm pack)
     - npm install -g $tgzfile
     - mkdir -p "$PREFIX"/etc/conda/{de,}activate.d/
     - cp conda-recipe/mountainlab_activate.sh "$PREFIX"/etc/conda/activate.d/
     - cp conda-recipe/mountainlab_deactivate.sh "$PREFIX"/etc/conda/deactivate.d/
+    - mkdir -p "$PREFIX"/etc/mountainlab/{packages,database}
 
 requirements:
   build:
@@ -27,6 +28,7 @@ test:
   commands:
     - npm list -g mountainlab-js
     - ml-config
+    - ml-list-processors
   requires:
     - nodejs
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,3 @@
-#Automatically generating npm conda package
 {% set data = load_npm() %}
 package:
   name: {{data.get('name').lower()}}
@@ -6,13 +5,16 @@ package:
 
 source:
   git_url: .. # relative to recipe dir
-  git_rev:
+  git_rev: HEAD
 
 build:
-  number: {% block build_number %}1{% endblock %}
+  number: 2
   script:
     - tgzfile=$(npm pack)
     - npm install -g $tgzfile
+    - mkdir -p "$PREFIX"/etc/conda/{de,}activate.d/
+    - cp conda-recipe/mountainlab_activate.sh "$PREFIX"/etc/conda/activate.d/
+    - cp conda-recipe/mountainlab_deactivate.sh "$PREFIX"/etc/conda/deactivate.d/
 
 requirements:
   build:
@@ -32,6 +34,4 @@ about:
   home: {{data.get('repository').get('url')}}
   license: {{data.get('license')}}
 
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml
+# based on template at https://github.com/conda/conda-build/blob/master/conda_build/templates/npm.yaml

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,37 @@
+#Automatically generating npm conda package
+{% set data = load_npm() %}
+package:
+  name: {{data.get('name').lower()}}
+  version: {{data.get('version')}}
+
+source:
+  git_url: .. # relative to recipe dir
+  git_rev:
+
+build:
+  number: {% block build_number %}1{% endblock %}
+  script:
+    - tgzfile=$(npm pack)
+    - npm install -g $tgzfile
+
+requirements:
+  build:
+    - nodejs
+
+  run:
+    - nodejs
+
+test:
+  commands:
+    - npm list -g mountainlab-js
+    - ml-config
+  requires:
+    - nodejs
+
+about:
+  home: {{data.get('repository').get('url')}}
+  license: {{data.get('license')}}
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/conda-recipe/mountainlab_activate.sh
+++ b/conda-recipe/mountainlab_activate.sh
@@ -1,24 +1,25 @@
-#!/bin/bash -e
-echo "=== [ mountainlab-js activate script ] ======================================="
-echo ":"
+#echo "=== [ mountainlab-js activate script ] ======================================="
+#echo ":"
 
-# This will be default mountainlab dir (equivalent to ~/.mountainlab) for this install
-mldir_conda="${CONDA_PREFIX?}"/etc/mountainlab
+# These dirs are created on install (see conda-recipe/meta.yaml)
+export ML_CONDA_DIR="${CONDA_PREFIX?}"/etc/mountainlab
+export ML_CONDA_PACKAGES_DIR="$ML_CONDA_DIR"/packages
+export ML_CONDA_DATABASE_DIR="$ML_CONDA_DIR"/database
 
 # if user has specified ML_CONFIG_DIRECTORY, warn, but don't overwrite it
-if [ -z "$ML_CONFIG_DIRECTORY" ]; then
-    echo ": OK! Default mountainlab search path for active env ${CONDA_PROMPT_MODIFIER}is:"
-    echo ":     '$mldir_conda'"
-    export ML_CONFIG_DIRECTORY=$mldir_conda
-    export MLCONFDIR_WASEMPTY=true
-else 
-    if [ -n "$MLCONFDIR_WASEMPTY" ] && [ "$ML_CONFIG_DIRECTORY" = "$mldir_conda" ]; then 
-	echo ": OK! Reactivation, nothing to do."
+if [ -z "$ML_CONFIG_DIRECTORY" ] ; then
+#    echo ": OK! Default mountainlab search path for active env (${CONDA_DEFAULT_ENV}) is:"
+#    echo ":     '$ML_CONDA_DIR'"
+    export ML_CONFIG_DIRECTORY=$ML_CONDA_DIR
+    export ML_CONFDIR_WASEMPTY=true
+else
+    if [ -n "$MLCONFDIR_WASEMPTY" ] && [ "$ML_CONFIG_DIRECTORY" = "$ML_CONDA_DIR" ]; then 
+	echo ": OK! mountainlab env reactivation, nothing to do."
     else
 	echo ": WARN! Default mountainlab search path already set ('$ML_CONFIG_DIRECTORY')."
 	echo ":       This may override conda search paths; run 'unset ML_CONFIG_DIRECTORY' to reset."
     fi
 fi
-echo ":"
-echo ": Run 'ml-config' to see all search paths in use."
-echo "==============================================================================="
+#echo ":"
+#echo ": Run 'ml-config' to see all search paths in use."
+#echo "==============================================================================="

--- a/conda-recipe/mountainlab_activate.sh
+++ b/conda-recipe/mountainlab_activate.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+echo "=== [ mountainlab-js activate script ] ======================================="
+echo ":"
+
+# This will be default mountainlab dir (equivalent to ~/.mountainlab) for this install
+mldir_conda="${CONDA_PREFIX?}"/etc/mountainlab
+
+# if user has specified ML_CONFIG_DIRECTORY, warn, but don't overwrite it
+if [ -z "$ML_CONFIG_DIRECTORY" ]; then
+    echo ": OK! Default mountainlab search path for active env ${CONDA_PROMPT_MODIFIER}is:"
+    echo ":     '$mldir_conda'"
+    export ML_CONFIG_DIRECTORY=$mldir_conda
+    export MLCONFDIR_WASEMPTY=true
+else 
+    if [ -n "$MLCONFDIR_WASEMPTY" ] && [ "$ML_CONFIG_DIRECTORY" = "$mldir_conda" ]; then 
+	echo ": OK! Reactivation, nothing to do."
+    else
+	echo ": WARN! Default mountainlab search path already set ('$ML_CONFIG_DIRECTORY')."
+	echo ":       This may override conda search paths; run 'unset ML_CONFIG_DIRECTORY' to reset."
+    fi
+fi
+echo ":"
+echo ": Run 'ml-config' to see all search paths in use."
+echo "==============================================================================="

--- a/conda-recipe/mountainlab_deactivate.sh
+++ b/conda-recipe/mountainlab_deactivate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+echo "=== [ mountainlab-js deactivation ] ==========================================="
+echo ":"
+mldir_conda="${CONDA_PREFIX?}"/etc/mountainlab
+
+# if we set confdir on activation, and it hasn't changed, unset it.
+if [ -n "$MLCONFDIR_WASEMPTY" ] && [ "$ML_CONFIG_DIRECTORY" = "$mldir_conda" ]; then
+    echo ": Deactivating mountainlab search path for env ${CONDA_PROMPT_MODIFIER}."
+    unset ML_CONFIG_DIRECTORY 
+    unset MLCONFDIR_WASEMPTY
+else 
+    if [ -n "$ML_CONFIG_DIRECTORY" ]; then
+	echo ": User-set ML_CONFIG_DIRECTORY left unchanged ( '$ML_CONFIG_DIRECTORY' )."
+    else
+	echo ": ML_CONFIG_DIRECTORY already unset/null, nothing to do"
+    fi
+fi
+echo ":"
+echo "==============================================================================="

--- a/conda-recipe/mountainlab_deactivate.sh
+++ b/conda-recipe/mountainlab_deactivate.sh
@@ -1,19 +1,22 @@
-#!/bin/bash -e
-echo "=== [ mountainlab-js deactivation ] ==========================================="
-echo ":"
-mldir_conda="${CONDA_PREFIX?}"/etc/mountainlab
+#!/bin/bash
+#echo "=== [ mountainlab-js deactivation ] ==========================================="
+#echo ":"
 
 # if we set confdir on activation, and it hasn't changed, unset it.
-if [ -n "$MLCONFDIR_WASEMPTY" ] && [ "$ML_CONFIG_DIRECTORY" = "$mldir_conda" ]; then
-    echo ": Deactivating mountainlab search path for env ${CONDA_PROMPT_MODIFIER}."
+if [ -n "$ML_CONFDIR_WASEMPTY" ] && [ "$ML_CONFIG_DIRECTORY" = "$ML_CONDA_DIR" ]; then
+#    echo ": Deactivating mountainlab search path for env (${CONDA_DEFAULT_ENV})."
     unset ML_CONFIG_DIRECTORY 
-    unset MLCONFDIR_WASEMPTY
 else 
     if [ -n "$ML_CONFIG_DIRECTORY" ]; then
-	echo ": User-set ML_CONFIG_DIRECTORY left unchanged ( '$ML_CONFIG_DIRECTORY' )."
+	echo ": Original user-set ML_CONFIG_DIRECTORY left unchanged ( '$ML_CONFIG_DIRECTORY' )."
     else
 	echo ": ML_CONFIG_DIRECTORY already unset/null, nothing to do"
     fi
 fi
-echo ":"
-echo "==============================================================================="
+#echo ":"
+#echo "==============================================================================="
+
+unset ML_CONFDIR_WASEMPTY
+unset ML_CONDA_DIR
+unset ML_CONDA_PACKAGES_DIR
+unset ML_CONDA_DATABASE_DIR

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "expand-home-dir": "0.0.3",
     "kbclient": "^1.1.0",
     "matcher": "latest",
-    "mongodb": "latest",
     "node-sha1": "latest",
     "request": "^2.85.0",
     "url-exists": "^1.0.3"

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,13 +1,6 @@
 #/bin/bash
-
-set -e
-if [ -z "$GLOBAL_INSTALL_FLAG" ]
-then
-    echo [testing a local install]
-    DIR=`dirname $0`
-    export PATH=$DIR/../bin:$PATH
-else
-    echo [ testing a global install, npm bin -g = $(npm bin -g) ]
-fi
-
+set -e -u
+# npm runs scripts from the package root (https://docs.npmjs.com/cli/run-script)
+export PATH="$PWD"/bin:"$PATH"; 
+ml-config
 ml-list-processors


### PR DESCRIPTION
[Replacing PR #30]

Adds conda recipe to build a mountainlab-js conda package.

The packages built by this recipe are currently available as version 0.4.1-1 for macOS and Linux on https://anaconda.org/franklab/mountainlab-js/files

You can test these by running `conda install -c franklab mountainlab-js`
(or `conda install franklab::mountainlab-js[=0.4.1-1]` to test this specific package).

The recipe currently requires nodejs, and puts all the mountainlab binaries on your path, but doesn't set up any packages or environment variables.

Also adds Travis-CI support for testing the conda build process, as well as testing a conda-based install.