### PR TITLE
Make database path respect correct config directory location

### DIFF
--- a/mlproc/common.js
+++ b/mlproc/common.js
@@ -21,6 +21,7 @@ exports.config_file_path=config_file_path;
 exports.config_directory=config_directory;
 exports.main_package_directory=main_package_directory;
 exports.shub_cache_directory=shub_cache_directory;
+exports.database_directory=database_directory;
 
 const LariClient=require('lariclient').v1;
 
@@ -511,4 +512,12 @@ function make_random_id(len) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
 
     return text;
+}
+
+function database_directory() {
+	let ret=process.env.ML_DATABASE_DIRECTORY||(config_directory()+'/database');
+	if (!require('fs').existsSync(ret)) {
+		require('fs').mkdirSync(ret);
+	}
+	return ret;
 }

--- a/mlproc/db_utils.js
+++ b/mlproc/db_utils.js
@@ -1,16 +1,10 @@
 const SafeDatabase=require(__dirname+'/safedatabase.js').SafeDatabase;
+let common=require(__dirname+'/common.js');
 
 let TheSafeDatabase=null;
 function load_database() {
 	if (!TheSafeDatabase) {
-		var dirpath=process.env.ML_DATABASE_DIRECTORY;
-		if (!dirpath) {
-			mkdir_if_needed(config_directory());
-			dirpath=config_directory()+'/database';
-		}
-		mkdir_if_needed(dirpath);
-
-		TheSafeDatabase=new SafeDatabase(dirpath);
+	        TheSafeDatabase=new SafeDatabase(common.database_directory());
 	}
 	return TheSafeDatabase;
 }
@@ -111,13 +105,7 @@ function connect_to_database_if_needed(callback) {
 	var hold_console_log=console.log;
 	console.log=function() {};
 	try {
-		var dirpath=process.env.ML_DATABASE_DIRECTORY;
-		if (!dirpath) {
-			mkdir_if_needed(config_directory());
-			dirpath=config_directory()+'/database';
-		}
-		mkdir_if_needed(dirpath);
-		DATABASE=Client.connect(dirpath,['sumit']);
+	        DATABASE=Client.connect(common.database_directory(),['sumit']);
 	}
 	catch(err) {
 		console.log=hold_console_log;
@@ -192,16 +180,4 @@ function removeDocuments_old(collection,query,callback) {
 		});
 		*/
 	});
-}
-
-function mkdir_if_needed(path) {
-  try {
-    require('fs').mkdirSync(path);
-  }
-  catch(err) {
-  }
-}
-
-function config_directory() {
-	return process.env.ML_CONFIG_DIRECTORY||process.env.HOME+'/.mountainlab';
 }

--- a/mlproc/display_config.js
+++ b/mlproc/display_config.js
@@ -26,7 +26,8 @@ function cmd_config(name,opts,callback) {
         'ML_TEMPORARY_DIRECTORY',
         'ML_PACKAGE_SEARCH_DIRECTORY',
         'ML_ADDITIONAL_PACKAGE_SEARCH_DIRECTORIES',
-        'ML_ADDITIONAL_PRV_SEARCH_DIRECTORIES'
+        'ML_ADDITIONAL_PRV_SEARCH_DIRECTORIES',
+	'ML_DATABASE_DIRECTORY'
     ];
     for (var i in env_names) {
         txt=txt.split(`$${env_names[i]}$`).join((process.env[env_names[i]]||'[default]'));
@@ -35,12 +36,14 @@ function cmd_config(name,opts,callback) {
     txt=txt.split('$temporary_directory$').join(common.temporary_directory());
     txt=txt.split('$package_search_directories$').join(common.package_search_directories().join(':'));
     txt=txt.split('$prv_search_directories$').join(common.prv_search_directories().join(':'));
+    txt=txt.split('$database_directory$').join(common.database_directory());
 
 	if (opts['format']=='json') {
 		var obj={
 			temporary_directory:common.temporary_directory(),
 			package_search_directories:common.package_search_directories(),
-			prv_search_directories:common.prv_search_directories()
+		        prv_search_directories:common.prv_search_directories(),
+		        database_directory:common.database_directory()
 		};
 		console.log (JSON.stringify(obj,null,4));
 	}

--- a/mlproc/display_config.template
+++ b/mlproc/display_config.template
@@ -10,17 +10,19 @@ environment variable.
 The following environment variables are being used.
 They can be set in the configuration file (see above),
 although existing environment variables will not be
-overriden by these values.
+overriden by configuration file entries.
 
 ML_TEMPORARY_DIRECTORY: $ML_TEMPORARY_DIRECTORY$
 ML_PACKAGE_SEARCH_DIRECTORY: $ML_PACKAGE_SEARCH_DIRECTORY$
 ML_ADDITIONAL_PACKAGE_SEARCH_DIRECTORIES: $ML_ADDITIONAL_PACKAGE_SEARCH_DIRECTORIES$
 ML_ADDITIONAL_PRV_SEARCH_DIRECTORIES: $ML_ADDITIONAL_PRV_SEARCH_DIRECTORIES$
+ML_DATABASE_DIRECTORY: $ML_DATABASE_DIRECTORY$
 
 The following are the values actually being used:
 
 Temporary directory: $temporary_directory$
-Package search_directories: $package_search_directories$
+Package search directories: $package_search_directories$
 PRV search directories: $prv_search_directories$
+Database directory: $database_directory$
 
 -----------------------------------------------------------


### PR DESCRIPTION
The 'database' directory was still getting written to ~/.mountainlab, even with a conda install.

This can lead to some unexpected interactions when MountainLab is installed in more than one conda env.